### PR TITLE
make changes to support ipv6

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func getMasterAddr(sentinelAddress *net.TCPAddr, masterName string) (*net.TCPAdd
 	}
 
 	//getting the string address for the master node
-	stringaddr := fmt.Sprintf("%s:%s", parts[2], parts[4])
+	stringaddr := fmt.Sprintf("[%s]:%s", parts[2], parts[4])
 	addr, err := net.ResolveTCPAddr("tcp", stringaddr)
 
 	if err != nil {


### PR DESCRIPTION
Presently, if IPv6 environment is used. The code will be able to ask the redis-sentinel about the master address. The master address returned will be in IPv6 for e.g. 2001:0db8:85a3:0000:0000:8a2e:0370:7334. When the code will append the port no.(6379) the new address would be 2001:0db8:85a3:0000:0000:8a2e:0370:733:6379 which is incorrect. 

An easy fix is to use square brackets. i.e. [2001:0db8:85a3:0000:0000:8a2e:0370:733]:6379.

I have tested it on my setup and it is working smoothly.